### PR TITLE
EUTHEME-101 (nexteuropa_formatters fix)

### DIFF
--- a/nexteuropa_formatters/nexteuropa_formatters.module
+++ b/nexteuropa_formatters/nexteuropa_formatters.module
@@ -354,7 +354,7 @@ function nexteuropa_formatters_module_implements_alter(&$implementations, $hook)
  * make sure that our custom settings are stored in the $field_settings array.
  */
 function nexteuropa_formatters_ds_field_settings_alter(&$field_settings, $form, &$form_state) {
-  if (isset($form_state['formatter_settings'])) {
+  if (!empty($form_state['formatter_settings'])) {
     foreach ($form_state['formatter_settings'] as $field => $setting) {
       if (isset($form_state['formatter_settings'][$field]['ft']['func'])) {
         if ($form_state['formatter_settings'][$field]['ft']['func'] == 'theme_ds_field_nexteuropa_formatters_meta_item') {


### PR DESCRIPTION
## Issue [EUTHEME-101](https://webgate.ec.europa.eu/CITnet/jira/browse/EUTHEME-101)

In the ticket there is an mention that this happens when adding fields on a template, which is true because without template the function is not called.