### PR TITLE
DTTSB-676 (File download asset should use brackets, one decimal place, and non-breaking space)

### DIFF
--- a/nexteuropa_formatters/nexteuropa_formatters.module
+++ b/nexteuropa_formatters/nexteuropa_formatters.module
@@ -518,6 +518,8 @@ function nexteuropa_formatters_ds_field_theme_functions_info() {
  *   HTML markup. NULL if no url is available.
  */
 function _nexteuropa_formatters_file_markup($file, $modifier = NULL, $subfile = FALSE, $is_external = FALSE, $url = []) {
+  global $language_content;
+
   if (empty($url)) {
     if (!$url['path'] = file_create_url($file->uri)) {
       return NULL;
@@ -541,8 +543,8 @@ function _nexteuropa_formatters_file_markup($file, $modifier = NULL, $subfile = 
   if (isset($file->entity->language) || isset($file->language)) {
     $language_to_use = isset($file->entity->language) ? entity_translation_get_existing_language('node', $file->entity) : $file->language;
     $file_language_string = _nexteuropa_theme_functions_get_language_obj($language_to_use, 'native');
-    if (!$subfile && module_exists('locale') && isset($GLOBALS['language_content']->language)) {
-      $file_language_string = locale($file_language_string, NULL, $GLOBALS['language_content']->language);
+    if (!$subfile && module_exists('locale') && isset($language_content->language)) {
+      $file_language_string = locale($file_language_string, NULL, $language_content->language);
     }
   }
 
@@ -578,7 +580,7 @@ function _nexteuropa_formatters_file_markup($file, $modifier = NULL, $subfile = 
   }
   else {
     $file_info_string = isset($file_language_string) ? '<span class="file__content-language">' . $file_language_string . ' </span>' : '';
-    $file_info_string .= !empty($file_info_parts) ? '(' . implode(' - ', $file_info_parts) . ')' : '';
+    $file_info_string .= !empty($file_info_parts) ? '<span class="file__properties">(' . implode(' - ', $file_info_parts) . '</span>)' : '';
 
     // Use the description as the link text if available.
     if (isset($file->entity)) {


### PR DESCRIPTION
## Issue [DTTSB-676](https://webgate.ec.europa.eu/CITnet/jira/browse/DTTSB-676)

**Notes:**
Adding `file__properties` class to the download component to display the properties size, type and number of pages in a new line when viewing in small devices like 320px.