### PR TITLE
EUTHEME-314 (Making the analytics menu item in the footer hidden)

### DIFF
--- a/nexteuropa_footer/nexteuropa_footer.features.menu_links.inc
+++ b/nexteuropa_footer/nexteuropa_footer.features.menu_links.inc
@@ -192,7 +192,7 @@ function nexteuropa_footer_menu_default_menu_links() {
       'identifier' => 'menu-nexteuropa-service-links_europa-analytics:https://webanalytics.ec.europa.eu',
     ),
     'module' => 'menu',
-    'hidden' => 0,
+    'hidden' => 1,
     'external' => 1,
     'has_children' => 0,
     'expanded' => 1,


### PR DESCRIPTION
The styleguide part of this implementation is in:
https://github.com/ec-europa/ec-europa-theme/pull/182